### PR TITLE
Ruby timezone

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -201,32 +201,32 @@ isFormReady = () => {
         myCountryOptions = document.querySelectorAll('select.country-mq option'),
         myFullCountryName = Array.prototype.find.call(myCountryOptions, (_option) => _option.value === myCountry);
 
-    // console.log(myCity, myCountry, myDay, myMonth, myYear, myHour, myMinutes, myFullCountryName.innerHTML);
+   // console.log(myCity, myCountry, myDay, myMonth, myYear, myHour, myMinutes, myFullCountryName.innerHTML);
 
-    fetchC.apiCall(`https://ts--api--rest.herokuapp.com/cities/iana/${myCity}/${myFullCountryName.innerHTML}`)
-    .then(_d => {
-      // console.log(_d.iana_code);
+    // fetchC.apiCall(`https://ts--api--rest.herokuapp.com/cities/iana/${myCity}/${myFullCountryName.innerHTML}`)
+    // .then(_d => {
 
-      const lux = luxon.DateTime.fromObject({year: myYear, month: myMonth, day: myDay, hour: myHour, minute: myMinutes }, { zone: _d.iana_code});
+    //   const lux = luxon.DateTime.fromObject({year: myYear, month: myMonth, day: myDay, hour: myHour, minute: myMinutes }, { zone: _d.iana_code});
 
-      let myInfo = document.createElement('p'),
-          compiledHour = parseInt(myHour) + (-(lux.o / 60)) + (parseInt(myMinutes) * 100 / 60) / 100;
+    //   console.log(lux);
 
-      myInfo.className = 'alert alert-success';
-      myInfo.innerHTML = `TimeZone is <span>${_d.iana_code}</span> and UTC offset is <span>${-(lux.o / 60)} and the compiled hour is ${compiledHour}</span>`;
+    //   let myInfo = document.createElement('p'),
+    //       compiledHour = parseInt(myHour) + (-(lux.o / 60)) + (parseInt(myMinutes) * 100 / 60) / 100;
 
-      document.getElementById('hour').value = compiledHour; //Change the hour before sending to back
+    //   myInfo.className = 'alert alert-success';
+    //   myInfo.innerHTML = `TimeZone is <span>${_d.iana_code}</span> and UTC offset is <span>${-(lux.o / 60)} and the compiled hour is ${compiledHour}</span>`;
 
-      insertAfter(myInfo, document.querySelector('ul.nav')); //insert Alert on top of page
+    //   //document.getElementById('hour').value = compiledHour; //Change the hour before sending to back
+
+    //   //insertAfter(myInfo, document.querySelector('ul.nav')); //insert Alert on top of page
+
+    //   // setTimeout( () => {
+    //   //   // myInfo.classList.add('faded');
+    //   //   myInfo.parentNode.removeChild(myInfo);
+    //   // }, 10000);
 
 
-      setTimeout( () => {
-        // myInfo.classList.add('faded');
-        myInfo.parentNode.removeChild(myInfo);
-      }, 10000);
-
-
-    });
+    // });
 
 
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -139,9 +139,6 @@ const mapQuestCall = (_countryCode, _cityName) => {
 
   });
 
-
-
-
 }
 
 /* ==================================================
@@ -151,14 +148,6 @@ LOGIC FUNCTION
 const setFormCoordinates = (_lat,_lng) => {
   document.getElementById('latitude').value = _lat;
   document.getElementById('longitude').value = _lng;
-
-  // Experimental visual info for user once lat, long are set
-  // L.mapquest.key = mapQuestKey;
-  //
-  // L.mapquest.geocoding().reverse({lat:_lat,lng:_lng}, (error, response) => {
-  //   console.log('reverse response is ');
-  //   console.dir(response);
-  // });
 
   document.querySelector('input.msg-mq').value = 'Located at ' + _lat.toFixed(2) + ' lat, ' + _lng.toFixed(2) + ' lng';
 
@@ -176,17 +165,7 @@ isFormReady = () => {
 
   //if we are not showing the map locked message we do not have geo coordinates. Form is not ready
 
-  //console.log(document.querySelector('div.mq-ui--miniform').classList);
-
   !document.querySelector('div.mq-ui--miniform').classList.contains('show-msg') ? ready = false : null;
-
-
-  /**
-   * 
-   * 
-   * TEMP CODE FOR TIMEZONE / OFFSET VISUAL INDICATOR
-   * 
-   */
 
   if(ready) {
     mySubmitBtn.classList.contains('disabled') ? mySubmitBtn.classList.remove('disabled') : null;
@@ -201,45 +180,9 @@ isFormReady = () => {
         myCountryOptions = document.querySelectorAll('select.country-mq option'),
         myFullCountryName = Array.prototype.find.call(myCountryOptions, (_option) => _option.value === myCountry);
 
-   // console.log(myCity, myCountry, myDay, myMonth, myYear, myHour, myMinutes, myFullCountryName.innerHTML);
-
-    // fetchC.apiCall(`https://ts--api--rest.herokuapp.com/cities/iana/${myCity}/${myFullCountryName.innerHTML}`)
-    // .then(_d => {
-
-    //   const lux = luxon.DateTime.fromObject({year: myYear, month: myMonth, day: myDay, hour: myHour, minute: myMinutes }, { zone: _d.iana_code});
-
-    //   console.log(lux);
-
-    //   let myInfo = document.createElement('p'),
-    //       compiledHour = parseInt(myHour) + (-(lux.o / 60)) + (parseInt(myMinutes) * 100 / 60) / 100;
-
-    //   myInfo.className = 'alert alert-success';
-    //   myInfo.innerHTML = `TimeZone is <span>${_d.iana_code}</span> and UTC offset is <span>${-(lux.o / 60)} and the compiled hour is ${compiledHour}</span>`;
-
-    //   //document.getElementById('hour').value = compiledHour; //Change the hour before sending to back
-
-    //   //insertAfter(myInfo, document.querySelector('ul.nav')); //insert Alert on top of page
-
-    //   // setTimeout( () => {
-    //   //   // myInfo.classList.add('faded');
-    //   //   myInfo.parentNode.removeChild(myInfo);
-    //   // }, 10000);
-
-
-    // });
-
-
-
-    
-
-
-  }else {
+      }else {
     !mySubmitBtn.classList.contains('disabled') ? mySubmitBtn.classList.add('disabled') : null;
   }
-
-
-  
-
 
 },
 toggleCityInput = () => {
@@ -329,8 +272,6 @@ addInteractions = () => {
     });
 
 
-
-
     myMapQuestButton.map( (_obj) => {
 
       _obj.addEventListener('click', (e) => {
@@ -410,12 +351,6 @@ addInteractions = () => {
 
 },
 init = e => {
-
-	//const lux = luxon.DateTime.fromObject({year: 1978, month: 9, day: 9, hour: 4, minute: 40 }, { zone: 'Europe/Madrid' });
-
-  //console.log(lux.o / 60);  
-
-
 
 
   document.removeEventListener('turbolinks:load', init, false);

--- a/app/models/client_data.rb
+++ b/app/models/client_data.rb
@@ -1,17 +1,26 @@
 class ClientData
-  attr_reader :latitude, :longitude, :altitude, :year, :month, :day, :hour, :local_time
+  attr_reader :latitude, :longitude, :altitude, :year, :month, :day, :hour, :minutes, :local_time
 
   def initialize(params)
-    # binding.pry
     @latitude = params[:latitude].to_f
     @longitude = params[:longitude].to_f
     @altitude = 0
     @year = params[:year].to_i
     @month = params[:month].to_i
     @day = params[:day].to_i
-    # data = params[:hour].delete(' ').split(':')
-    @hour = params[:hour].to_f
-    # @minutes = data.last.to_i
+    data = params[:hour].delete(' ').split(':')
+    @hour = params[:hour].to_i
+    #@minutes = params[:minutes].to_i
+    @minutes = data.last.to_i
+    @hour = compiled_time
+  end
+
+  def compiled_time
+    #binding.pry
+    timezone = Timezone.lookup(@latitude,@longitude)
+    date = DateTime.new(@year,@month,@day,@hour,@minutes)
+    time_offset = (timezone.time_with_offset(date)).gmt_offset.to_i / 3600
+    result = ((@hour + (-(time_offset))) + ((@minutes * 100 / 60).to_f / 100)).to_f
   end
 
   def local_time

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -10,5 +10,4 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   <script src="https://api.mqcdn.com/sdk/mapquest-js/v1.3.2/mapquest.js" data-turbolinks-track="reload"></script>
-  <script src="https://cdn.jsdelivr.net/npm/luxon@2.0.1/build/global/luxon.min.js" data-turbolinks-track="reload"></script>
 </head>


### PR DESCRIPTION
Esta rama funciona usando la gema timezone de ruby tal y como queriamos. Eliminé el codigo  que usabamos en application.js del lado del cliente ( las llamadas a la libreria luxon y a la API que tenía en Heroku.) 

Ahora el offset lo calculamos desde el back una vez nos entran los datos del formulario sin llamadas externas más que para la API del mapa.